### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:focal
 
 RUN apt-get update && \
-    apt-get --yes install python3-flask-sqlalchemy python3-pymysql wget && \
-    apt-get clean && \
-    mkdir /agama && \
-    wget -O/agama/agama.py https://raw.githubusercontent.com/hudolejev/agama/master/agama.py
+    apt-get --yes install python3-flask-sqlalchemy python3-pymysql && \
+    apt-get clean
+
+WORKDIR /agama
+
+COPY agama.py .
 
 ENV AGAMA_DATABASE_URI=sqlite:////agama/db.sqlite3
 ENV FLASK_APP=agama
 
 EXPOSE 8000/tcp
-
-WORKDIR /agama
 
 CMD ["flask", "run", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Use local copy of `agama.py` instead of downloading it from GitHub.

This solves known issues caused by MTU size in some environments, seen as `wget` hanging forever:

```
--2022-11-12 18:17:50--  https://raw.githubusercontent.com/hudolejev/agama/master/agama.py
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.110.133, 185.199.109.133, 185.199.108.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.110.133|:443... connected.
```